### PR TITLE
Use environment variables for database and SMS secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# Copy this file to .env and populate it with your environment-specific values.
+# Never commit the filled .env file with real credentials.
+
+# Database configuration
+DB_HOST=your-database-host
+DB_NAME=your-database-name
+DB_USERNAME=your-database-username
+DB_PASSWORD=your-database-password
+
+# SMS service configuration
+SMS_API_SEND_URL=https://api.afromessage.com/api/send
+SMS_API_BULK_URL=https://api.afromessage.com/api/bulk_send
+SMS_API_TOKEN=your-afromessage-api-token
+SMS_FROM_ID=
+SMS_SENDER_ID=your-sender-id
+SMS_CALLBACK_URL=
+SMS_STATUS_CALLBACK=
+SMS_CREATE_CALLBACK=
+SMS_DEFAULT_CAMPAIGN=

--- a/config/Database.php
+++ b/config/Database.php
@@ -3,19 +3,31 @@
 
 class Database{
 
-    //db params
-   // private $host = 'localhost';
-   // private $db_name = 'ngus_merkato';
-    //private $username = 'root';
-    //private $password = '';
-
-        //db params
-        private $host = '109.70.148.60';
-        private $db_name = 'kulushrk_ngus_merkato';
-        private $username = 'kulushrk_welsh';
-        private $password = 'w#t59Ud13';
+    private $host;
+    private $db_name;
+    private $username;
+    private $password;
 
     private $conn;
+
+    public function __construct()
+    {
+        $this->host = $this->getRequiredEnv('DB_HOST');
+        $this->db_name = $this->getRequiredEnv('DB_NAME');
+        $this->username = $this->getRequiredEnv('DB_USERNAME');
+        $this->password = $this->getRequiredEnv('DB_PASSWORD');
+    }
+
+    private function getRequiredEnv($key)
+    {
+        $value = getenv($key);
+
+        if ($value === false || $value === '') {
+            throw new RuntimeException("Environment variable {$key} is not set.");
+        }
+
+        return $value;
+    }
 
     public function connect(){
 

--- a/docs/environment-configuration.md
+++ b/docs/environment-configuration.md
@@ -1,0 +1,42 @@
+# Environment Configuration
+
+This project now relies on environment variables for sensitive configuration. Populate the variables in your hosting environment or through a local `.env` file that is **never** committed to version control.
+
+## Required variables
+
+| Variable | Description |
+| --- | --- |
+| `DB_HOST` | Database host name or IP address. |
+| `DB_NAME` | Database schema to connect to. |
+| `DB_USERNAME` | Database user account. |
+| `DB_PASSWORD` | Database user password. |
+| `SMS_API_SEND_URL` | HTTPS endpoint for single SMS submissions. |
+| `SMS_API_BULK_URL` | HTTPS endpoint for bulk SMS submissions. |
+| `SMS_API_TOKEN` | Bearer token issued by the SMS provider. |
+| `SMS_SENDER_ID` | Registered sender ID for outbound SMS messages. |
+
+### Optional variables
+
+| Variable | Description |
+| --- | --- |
+| `SMS_FROM_ID` | Messaging profile identifier used by the SMS provider. |
+| `SMS_CALLBACK_URL` | Callback URL for single message status updates. |
+| `SMS_STATUS_CALLBACK` | Callback URL for bulk message status updates. |
+| `SMS_CREATE_CALLBACK` | Callback URL for bulk message creation events. |
+| `SMS_DEFAULT_CAMPAIGN` | Default campaign identifier for bulk messages. |
+
+## Local development
+
+1. Duplicate `.env.example` and rename it to `.env`.
+2. Provide real values for each variable. Leave optional values empty if they are not needed.
+3. Configure your web server or development environment to export the variables. For example:
+   ```bash
+   export $(grep -v '^#' .env | xargs)
+   ```
+4. Restart the PHP runtime so the new environment values are applied.
+
+## Production deployment
+
+* Prefer setting the variables directly in the hosting control panel or web server configuration (e.g., Apache `SetEnv`, Nginx `fastcgi_param`, or systemd service `Environment=` directives).
+* Rotate credentials regularly and store them in a secure secrets manager where possible.
+* Never commit `.env` files or plaintext secrets to this repository.

--- a/model/SMS.php
+++ b/model/SMS.php
@@ -1,21 +1,56 @@
 <?php
 
 class SMS{
-    
+
+    private $apiSendUrl;
+    private $apiBulkSendUrl;
+    private $apiToken;
+    private $from;
+    private $sender;
+    private $callback;
+    private $statusCallback;
+    private $createCallback;
+    private $campaign;
+
+    public function __construct()
+    {
+        $this->apiSendUrl = $this->getRequiredEnv('SMS_API_SEND_URL');
+        $this->apiBulkSendUrl = $this->getRequiredEnv('SMS_API_BULK_URL');
+        $this->apiToken = $this->getRequiredEnv('SMS_API_TOKEN');
+        $this->from = getenv('SMS_FROM_ID');
+        $this->from = $this->from === false ? '' : $this->from;
+        $this->sender = $this->getRequiredEnv('SMS_SENDER_ID');
+        $this->callback = getenv('SMS_CALLBACK_URL') ?: '';
+        $this->statusCallback = getenv('SMS_STATUS_CALLBACK') ?: '';
+        $this->createCallback = getenv('SMS_CREATE_CALLBACK') ?: '';
+        $this->campaign = getenv('SMS_DEFAULT_CAMPAIGN') ?: 'Fist campain';
+    }
+
+    private function getRequiredEnv($key)
+    {
+        $value = getenv($key);
+
+        if ($value === false || $value === '') {
+            throw new RuntimeException("Environment variable {$key} is not set.");
+        }
+
+        return $value;
+    }
+
     public function sendSms($tt,$mm){ /** We use php cURL for the samples **/
 
  /** We use php cURL for the samples **/
     $ch = curl_init();
     // base url
-	$url = 'https://api.afromessage.com/api/send';
-	$token = 'eyJhbGciOiJIUzI1NiJ9.eyJpZGVudGlmaWVyIjoiSlVuQWVlTzNZY0hET0UwbVpYNTJOcFA5WFlTMFc4MUMiLCJleHAiOjE4NzY1MDQ5MDIsImlhdCI6MTcxODczODUwMiwianRpIjoiN2Y1ZDQ1NWYtY2VlMC00OTBjLTljNjQtNzYwYjk4NjcwNDkyIn0.3in0WJhVcJnjj0x7juKzhZrVbowZFQHlZ8tZytBmNPY';
-    $from = '';
-    $sender = 'Merkato Pro';
-	$to = $tt;
-	$message = $mm;
-	$callback = '';
+        $url = $this->apiSendUrl;
+        $token = $this->apiToken;
+    $from = $this->from;
+    $sender = $this->sender;
+        $to = $tt;
+        $message = $mm;
+        $callback = $this->callback;
     // request body
-	$body = array("from" => $from,"sender" => $sender,"to" => $to,"message" => $message,"callback"=>$callback);
+        $body = array("from" => $from,"sender" => $sender,"to" => $to,"message" => $message,"callback"=>$callback);
 	
     /** configure request **/
 	curl_setopt($ch, CURLOPT_URL, $url);
@@ -63,15 +98,15 @@ class SMS{
              /** We use php cURL for the samples **/
     $ch = curl_init();
     // base url
-	$url = 'https://api.afromessage.com/api/bulk_send';
-	$token = 'eyJhbGciOiJIUzI1NiJ9.eyJpZGVudGlmaWVyIjoiSlVuQWVlTzNZY0hET0UwbVpYNTJOcFA5WFlTMFc4MUMiLCJleHAiOjE4NzY1MDQ5MDIsImlhdCI6MTcxODczODUwMiwianRpIjoiN2Y1ZDQ1NWYtY2VlMC00OTBjLTljNjQtNzYwYjk4NjcwNDkyIn0.3in0WJhVcJnjj0x7juKzhZrVbowZFQHlZ8tZytBmNPY';
-    $from = 'e80ad9d8-adf3-463f-80f4-7c4b39f7f164';
-    $sender = 'Merkato Pro';
+        $url = $this->apiBulkSendUrl;
+        $token = $this->apiToken;
+    $from = $this->from;
+    $sender = $this->sender;
 	$to = ['+251943080871','+251930694101','+251979149445','+251921923976','+251921538686','+251984722935','+251979300009','+251932219305','+2519941080475','+251951075409','+251943090921','+251911771486','+251922449334'];
 	$message = 'ከጥቂት ሰዓት ቦኋላ ወደ ሳሪስ እቃ እናደርሳለን። የምትፈልጉት እቃ ካለ ማዘዝ ትችላላቹ።';   
-	$camp = 'Fist campain';
-    $scb = '';
-    $ccb = '';
+        $camp = $this->campaign;
+    $scb = $this->statusCallback;
+    $ccb = $this->createCallback;
     // request body
 	$body = array("from" => $from,"sender" => $sender,"to" => $to,"message" => $message,"campaign"=>$camp,"statusCallback"=>$scb,"createCallback"=>$ccb);
 	
@@ -83,7 +118,7 @@ class SMS{
 
     /** request headers **/
 	$headers = array();
-	$headers[] = 'Authorization: Bearer '.$token;
+        $headers[] = 'Authorization: Bearer '.$token;
 	$headers[] = 'Content-Type: application/json';
 	curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
 
@@ -120,15 +155,15 @@ class SMS{
              /** We use php cURL for the samples **/
     $ch = curl_init();
     // base url
-	$url = 'https://api.afromessage.com/api/bulk_send';
-	$token = 'eyJhbGciOiJIUzI1NiJ9.eyJpZGVudGlmaWVyIjoiSlVuQWVlTzNZY0hET0UwbVpYNTJOcFA5WFlTMFc4MUMiLCJleHAiOjE4NzY1MDQ5MDIsImlhdCI6MTcxODczODUwMiwianRpIjoiN2Y1ZDQ1NWYtY2VlMC00OTBjLTljNjQtNzYwYjk4NjcwNDkyIn0.3in0WJhVcJnjj0x7juKzhZrVbowZFQHlZ8tZytBmNPY';
-    $from = 'e80ad9d8-adf3-463f-80f4-7c4b39f7f164';
-    $sender = 'Merkato Pro';
+        $url = $this->apiBulkSendUrl;
+        $token = $this->apiToken;
+    $from = $this->from;
+    $sender = $this->sender;
 	$to = $phones;
 	$message = $m;  
-	$camp = 'Fist campain';
-    $scb = '';
-    $ccb = '';
+        $camp = $this->campaign;
+    $scb = $this->statusCallback;
+    $ccb = $this->createCallback;
     // request body
 	$body = array("from" => $from,"sender" => $sender,"to" => $to,"message" => $message,"campaign"=>$camp,"statusCallback"=>$scb,"createCallback"=>$ccb);
 	


### PR DESCRIPTION
## Summary
- load database connection parameters from environment variables and fail fast when any are missing
- read SMS API credentials and identifiers from environment variables instead of literals
- document required environment variables and provide an example .env template for deployments

## Testing
- php -l config/Database.php
- php -l model/SMS.php

------
https://chatgpt.com/codex/tasks/task_e_68dbf53fe78c832ea8ef272df5840268